### PR TITLE
Support datetime encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.2
+
+  * Support Date/Time structs in metadata
+
 ## 0.1.1
 
   * Make Poison optional dependency, which will fix compilation warnings

--- a/lib/logstash_logger_formatter.ex
+++ b/lib/logstash_logger_formatter.ex
@@ -55,6 +55,10 @@ defmodule LogstashLoggerFormatter do
        when is_reference(md),
        do: inspect(md)
 
+  defp format_metadata(%type{} = dt) when type in [Date, Time, DateTime, NaiveDateTime] do
+    dt
+  end
+
   defp format_metadata(%_{} = md) do
     md
     |> Map.from_struct()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LogstashLoggerFormatter.Mixfile do
   def project do
     [
       app: :logstash_logger_formatter,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.4",
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,

--- a/test/logstash_logger_formatter_test.exs
+++ b/test/logstash_logger_formatter_test.exs
@@ -9,7 +9,7 @@ defmodule LogstashLoggerFormatterTest do
       :console,
       format: {LogstashLoggerFormatter, :format},
       colors: [enabled: false],
-      metadata: [:application, :extra_pid, :extra_map, :extra_tuple, :extra_ref]
+      metadata: [:application, :extra_pid, :extra_map, :extra_tuple, :extra_ref, :datetime]
     )
   end
 
@@ -40,5 +40,18 @@ defmodule LogstashLoggerFormatterTest do
     assert decoded_message["extra_ref"] == inspect(ref)
     assert decoded_message["extra_map"] == %{"key" => "value"}
     assert decoded_message["extra_tuple"] == ["el1", "el2"]
+  end
+
+  test "logs DateTime as a string" do
+    datetime = DateTime.utc_now()
+
+    message =
+      capture_log(fn ->
+        Logger.warn("Test message", datetime: datetime)
+      end)
+
+    decoded_message = Poison.decode!(message)
+
+    assert decoded_message["datetime"] == DateTime.to_iso8601(datetime)
   end
 end


### PR DESCRIPTION
Don't destruct Date/Time structs before encoding, let Poison handle it