### PR TITLE
Use JSON engine protocols to encode structs in metadata

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 elixir 1.6.0
+erlang 20.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+  * Use JSON engine protocols to encode structs in metadata
+
 ## 0.1.2
 
   * Support Date/Time structs in metadata

--- a/lib/logstash_logger_formatter.ex
+++ b/lib/logstash_logger_formatter.ex
@@ -55,14 +55,10 @@ defmodule LogstashLoggerFormatter do
        when is_reference(md),
        do: inspect(md)
 
-  defp format_metadata(%type{} = dt) when type in [Date, Time, DateTime, NaiveDateTime] do
-    dt
-  end
-
+  # Normally, structs shouldn't be passed to metadata, but if they're passed, we'll let
+  # Poison/Jason handle encoding of structs
   defp format_metadata(%_{} = md) do
     md
-    |> Map.from_struct()
-    |> format_metadata()
   end
 
   defp format_metadata(md) when is_map(md) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LogstashLoggerFormatter.Mixfile do
   def project do
     [
       app: :logstash_logger_formatter,
-      version: "0.1.2",
+      version: "0.2.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule LogstashLoggerFormatter.Mixfile do
       app: :logstash_logger_formatter,
       version: "0.1.2",
       elixir: "~> 1.4",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,
       deps: deps(),
@@ -38,6 +39,10 @@ defmodule LogstashLoggerFormatter.Mixfile do
       extra_applications: [:logger]
     ]
   end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
+%{
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.2", "993e0a95e9fbb790ac54ea58e700b45b299bd48bc44b4ae0404f28161f37a83e", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"}}
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+}

--- a/test/logstash_logger_formatter_test.exs
+++ b/test/logstash_logger_formatter_test.exs
@@ -54,4 +54,18 @@ defmodule LogstashLoggerFormatterTest do
 
     assert decoded_message["datetime"] == DateTime.to_iso8601(datetime)
   end
+
+  test "uses encoder protocol whenever possible" do
+    datetime = DateTime.utc_now()
+    struct = %CustomStruct{value: datetime}
+
+    message =
+      capture_log(fn ->
+        Logger.warn("Test message", datetime: struct)
+      end)
+
+    decoded_message = Poison.decode!(message)
+
+    assert decoded_message["datetime"] == DateTime.to_iso8601(datetime)
+  end
 end

--- a/test/support/support.ex
+++ b/test/support/support.ex
@@ -1,0 +1,9 @@
+defmodule CustomStruct do
+  defstruct [:value]
+
+  defimpl Poison.Encoder do
+    def encode(struct, opts) do
+      Poison.Encoder.encode(struct.value, opts)
+    end
+  end
+end


### PR DESCRIPTION
Some libraries may inject some structs into metadata (for example,
`tapper` injects `:trace_id` struct into metadata and only defines
implementation of `String.Chars` protocol for `Tapper.TraceId` struct).

Previous impementation forcefully converted such structs into maps
and encoded internals using some heuristics. This implementation restricts
developers from customizing how certain structs should be represented
in JSON logs. This change allows defining implementation of `Poison.Encoder`
or `Jason.Encoder` protocol for structs and it will be used by LogstashLoggerFormatter.

Note that Date/Time is a specific case of the abovementioned problem, so
the Date/Time handling code is deleted in favor of more general solution.

`Poison` by default encodes structs as maps, so this change shouldn't break anything for those who uses `Poison` as encoding engine