### PR TITLE
Add Elixir 1.10 support

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.9.4
+elixir 1.10.4-otp-22
 erlang 22.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: elixir
 elixir:
   - '1.8.2'
   - '1.9.3'
+  - '1.10.4'
 otp_release:
   - '21.3'
   - '22.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+  * Add support for Elixir 1.10 with OTP 22
+
 ## 0.3.0
 
   * Add support for Poison 4.x

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LogstashLoggerFormatter.Mixfile do
   def project do
     [
       app: :logstash_logger_formatter,
-      version: "0.3.0",
+      version: "0.4.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{
-  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},
-  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
+  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f1155337ae17ff7a1255217b4c1ceefcd1860b7ceb1a1874031e7a861b052e39"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "a10c6eb62cca416019663129699769f0c2ccf39428b3bb3c0cb38c718a0c186d"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
+  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm", "ba8836feea4b394bb718a161fc59a288fe0109b5006d6bdf97b6badfcf6f0f25"},
 }

--- a/test/logstash_logger_formatter_test.exs
+++ b/test/logstash_logger_formatter_test.exs
@@ -9,11 +9,11 @@ defmodule LogstashLoggerFormatterTest do
       :console,
       format: {LogstashLoggerFormatter, :format},
       colors: [enabled: false],
-      metadata: [:application, :extra_pid, :extra_map, :extra_tuple, :extra_ref, :datetime]
+      metadata: :all
     )
   end
 
-  test "logs message in JSON format" do
+  test "logs message in JSON format", %{test: test_name} do
     ref = make_ref()
     pid = self()
 
@@ -36,6 +36,8 @@ defmodule LogstashLoggerFormatterTest do
     assert decoded_message["otp_application"] == "otp_app"
     assert decoded_message["@timestamp"] =~ ~r[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+00:00]
     assert decoded_message["level"] == "warn"
+    assert decoded_message["module"] == "Elixir.#{inspect(__MODULE__)}"
+    assert decoded_message["function"] == "#{to_string(test_name)}/1"
     assert decoded_message["extra_pid"] == inspect(pid)
     assert decoded_message["extra_ref"] == inspect(ref)
     assert decoded_message["extra_map"] == %{"key" => "value"}

--- a/test/support/basic_types.ex
+++ b/test/support/basic_types.ex
@@ -1,0 +1,20 @@
+defmodule BasicTypes do
+  @moduledoc """
+  A good-enough-for-tests implementation for typeof. Useful when you do not care
+  what the exact type is, but to just compare different types.
+  """
+
+  def typeof(self) do
+    cond do
+      is_float(self) -> "float"
+      is_number(self) -> "number"
+      is_atom(self) -> "atom"
+      is_boolean(self) -> "boolean"
+      is_binary(self) -> "binary"
+      is_function(self) -> "function"
+      is_list(self) -> "list"
+      is_tuple(self) -> "tuple"
+      true -> "other"
+    end
+  end
+end


### PR DESCRIPTION
Logger changes required extracting the `module` and `function` metadata
separately starting from 1.10-otp-22.