### PR TITLE
Replace default JSON engine (Poison) with Jason

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.11.0-otp-23
-erlang 23.0
+elixir 1.11
+erlang 23.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0
+
+  * Change default JSON encoder to Jason
+
 ## 0.5.0
 
   * Add support for Elixir 1.11 with OTP 23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0
+
+  * Add support for Elixir 1.11 with OTP 23
+
 ## 0.4.0
 
   * Add support for Elixir 1.10 with OTP 22

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LogstashLoggerFormatter.Mixfile do
   def project do
     [
       app: :logstash_logger_formatter,
-      version: "0.5.0",
+      version: "1.0.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule LogstashLoggerFormatter.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:poison, "~> 1.0 or ~> 2.0 or ~> 3.0 or ~> 4.0", optional: true},
+      {:jason, "~> 1.0", optional: true},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,8 @@
 %{
-  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.10", "6603d7a603b9c18d3d20db69921527f82ef09990885ed7525003c7fe7dc86c56", [:mix], [], "hexpm", "8e2d5370b732385db2c9b22215c3f59c84ac7dda7ed7e544d7c459496ae519c0"},
   "ex_doc": {:hex, :ex_doc, "0.22.6", "0fb1e09a3e8b69af0ae94c8b4e4df36995d8c88d5ec7dbd35617929144b62c00", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "1e0aceda15faf71f1b0983165e6e7313be628a460e22a031e32913b98edbd638"},
+  "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},
   "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.15.0", "98312c9f0d3730fde4049985a1105da5155bfe5c11e47bdc7406d88e01e4219b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "75ffa34ab1056b7e24844c90bfc62aaf6f3a37a15faa76b07bc5eba27e4a8b4a"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
-  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm", "ba8836feea4b394bb718a161fc59a288fe0109b5006d6bdf97b6badfcf6f0f25"},
 }

--- a/test/logstash_logger_formatter_test.exs
+++ b/test/logstash_logger_formatter_test.exs
@@ -29,7 +29,7 @@ defmodule LogstashLoggerFormatterTest do
         )
       end)
 
-    decoded_message = Poison.decode!(message)
+    decoded_message = Jason.decode!(message)
 
     assert decoded_message["message"] == "Test message"
     assert decoded_message["application"] == "logstash_formatter"
@@ -58,7 +58,7 @@ defmodule LogstashLoggerFormatterTest do
         Logger.warn("Test message", datetime: datetime)
       end)
 
-    decoded_message = Poison.decode!(message)
+    decoded_message = Jason.decode!(message)
 
     assert decoded_message["datetime"] == DateTime.to_iso8601(datetime)
   end
@@ -72,7 +72,7 @@ defmodule LogstashLoggerFormatterTest do
         Logger.warn("Test message", datetime: struct)
       end)
 
-    decoded_message = Poison.decode!(message)
+    decoded_message = Jason.decode!(message)
 
     assert decoded_message["datetime"] == DateTime.to_iso8601(datetime)
   end

--- a/test/support/support.ex
+++ b/test/support/support.ex
@@ -1,9 +1,9 @@
 defmodule CustomStruct do
   defstruct [:value]
 
-  defimpl Poison.Encoder do
+  defimpl Jason.Encoder do
     def encode(struct, opts) do
-      Poison.Encoder.encode(struct.value, opts)
+      Jason.Encoder.encode(struct.value, opts)
     end
   end
 end


### PR DESCRIPTION
Almost all libraries nowadays use Jason. It's still possible to use Poison
but it is no longer default.