### PR TITLE
Fix logging functions in metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 language: elixir
 elixir:
-  - '1.8.2'
-  - '1.9.3'
-  - '1.10.4'
-  - '1.11.0'
+  - '1.9'
+  - '1.11'
 otp_release:
-  - '21.3'
   - '22.2'
   - '23.0'
 matrix:
   exclude: # Incompatible releases
-    - elixir: 1.8.2
-      otp_release: 23.0
-    - elixir: 1.9.3
+    - elixir: 1.9
       otp_release: 23.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+  * Avoid crashing when metadata includes a function
+
 ## 1.0.0
 
   * Change default JSON encoder to Jason

--- a/lib/logstash_logger_formatter.ex
+++ b/lib/logstash_logger_formatter.ex
@@ -78,6 +78,8 @@ defmodule LogstashLoggerFormatter do
        when is_reference(md),
        do: inspect(md)
 
+  defp format_metadata(md) when is_function(md), do: inspect(md)
+
   # Normally, structs shouldn't be passed to metadata, but if they're passed, we'll let
   # Poison/Jason handle encoding of structs
   defp format_metadata(%_{} = md) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LogstashLoggerFormatter.Mixfile do
   def project do
     [
       app: :logstash_logger_formatter,
-      version: "1.0.0",
+      version: "1.0.1",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/logstash_logger_formatter_test.exs
+++ b/test/logstash_logger_formatter_test.exs
@@ -77,6 +77,18 @@ defmodule LogstashLoggerFormatterTest do
     assert decoded_message["datetime"] == DateTime.to_iso8601(datetime)
   end
 
+  test "logs function as a string" do
+    function = &:application_controller.format_log/1
+
+    message =
+      capture_log(fn ->
+        Logger.warn("Test message", foo: function)
+      end)
+
+    decoded_message = Jason.decode!(message)
+    assert decoded_message["foo"] == "&:application_controller.format_log/1"
+  end
+
   defp all_of_same_type?(list) when is_list(list) do
     list |> Enum.map(&BasicTypes.typeof(&1)) |> Enum.uniq() |> Enum.count() == 1
   end


### PR DESCRIPTION
This fixes errors like:
```
** (exit) an exception was raised:
   ** (Protocol.UndefinedError) protocol Jason.Encoder not implemented for
&:application_controller.format_log/1 of type Function, Jason.Encoder
protocol must always be explicitly implemented. This protocol is
implemented for the following type(s): Ecto.Schema.Metadata,
Ecto.Association.NotLoaded, BitString, Date, Atom, NaiveDateTime, Map,
Decimal, DateTime, Time, Float, List, Any, Integer, Jason.Fragment
```

I'm not exactly sure where these errors are coming from, but according to
https://github.com/Nebo15/logger_json/issues/40 they are likely related to
newer OTP version itself.