### PR TITLE
Do not crash when logging structs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LogstashLoggerFormatter.Mixfile do
   def project do
     [
       app: :logstash_logger_formatter,
-      version: "1.0.1",
+      version: "1.0.2",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
We've now seen it in multiple places when something fails then the logger
produces noise. E.g:
``` protocol Jason.Encoder not implemented for %KeyError{key:
:on_terminate, message: nil, term: [[on_terminate: #Function<0.55733071/0
in SecretService.Application."-fun.terminate_background_processes/0-">]]}
of type KeyError (a struct), Jason.Encoder protocol must always be
explicitly implemented. If you own the struct, you can derive the
implementation specifying which fields should be encoded to JSON:
  @derive {Jason.Encoder, only: [....]}
  defstruct ...
```

This is because it tries to log out the error, but we don't have an encoder
for that particular struct. Here I add a fallback so we get the actual
errors, not crashes about logger not being able to handle exceptions.