### PR TITLE
Prune invalid UTF-8 bytes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,5 @@ jobs:
       - run: mix deps.compile
         env:
           MIX_ENV: test
+      - run: mix format --check-formatted
       - run: mix test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.2
+
+- Allow message and metadata to be logged in cases where it contains invalid UTF-8
+bytes. Previously, the formatter raised an error when it encountered such message.
+
 ## 1.1.1
 
   * Avoid crashing when metadata is iosteam and not a string.

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :logger,
-  :logstash_formatter,
-  extra_fields: %{application: :logstash_formatter},
-  max_metadata_size: 500,
-  max_metadata_item_size: 200
+       :logstash_formatter,
+       extra_fields: %{application: :logstash_formatter},
+       max_metadata_size: 500,
+       max_metadata_item_size: 200

--- a/lib/logstash_logger_formatter.ex
+++ b/lib/logstash_logger_formatter.ex
@@ -87,6 +87,7 @@ defmodule LogstashLoggerFormatter do
   end
 
   defp maybe_truncate_item(md) when is_number(md) or is_atom(md) or is_struct(md), do: md
+
   defp maybe_truncate_item(item) do
     if metadata_item_too_big?(item), do: truncate_item(item), else: item
   end
@@ -116,10 +117,15 @@ defmodule LogstashLoggerFormatter do
     keep_items_count = items_to_keep(metadata_byte_size(item), items_in_map)
 
     item_subset = Map.take(item, Enum.take(Map.keys(item), keep_items_count))
-    truncated_map = Enum.reduce(item_subset, %{}, fn {key, value}, acc ->
-      Map.put(acc, key, maybe_truncate_item(value))
-    end)
-    if keep_items_count < items_in_map, do: Map.put(truncated_map, "-pruned-", true), else: truncated_map
+
+    truncated_map =
+      Enum.reduce(item_subset, %{}, fn {key, value}, acc ->
+        Map.put(acc, key, maybe_truncate_item(value))
+      end)
+
+    if keep_items_count < items_in_map,
+      do: Map.put(truncated_map, "-pruned-", true),
+      else: truncated_map
   end
 
   defp truncate_item(item) do
@@ -127,7 +133,7 @@ defmodule LogstashLoggerFormatter do
   end
 
   defp items_to_keep(byte_size, length) do
-    max(floor((@max_metadata_item_size / byte_size) * length), 1)
+    max(floor(@max_metadata_item_size / byte_size * length), 1)
   end
 
   defp metadata_item_too_big?(md), do: metadata_byte_size(md) > @max_metadata_item_size

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LogstashLoggerFormatter.Mixfile do
   def project do
     [
       app: :logstash_logger_formatter,
-      version: "1.1.1",
+      version: "1.1.2",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/logstash_logger_formatter_test.exs
+++ b/test/logstash_logger_formatter_test.exs
@@ -115,173 +115,185 @@ defmodule LogstashLoggerFormatterTest do
   end
 
   test "truncates metadata" do
-    message = capture_log(fn ->
-      Logger.warn(
-        "Test message",
-        long_list: [
-          "some long string in it 1",
-          "some long string in it 2",
-          "some long string in it 3",
-          "some long string in it 4",
-          "some long string in it 5",
-          "some long string in it 6",
-          "some long string in it 7",
-          "some long string in it 8",
-          "some long string in it 9",
-          "some long string in it 10",
-          "some long string in it 11",
-          "some long string in it 12",
-          "some long string in it 13",
-          "some long string in it 14",
-          "some long string in it 15",
-          "some long string in it 16",
-          "some long string in it 17",
-          "some long string in it 18",
-          "some long string in it 19",
-          "some long string in it 20"
-        ],
-        long_list_with_maps: [
-          %{thing: "some long string in it 1"},
-          %{thing: "some long string in it 2"},
-          %{thing: "some long string in it 3"},
-          %{thing: "some long string in it 4"},
-          %{thing: "some long string in it 5"},
-          %{thing: "some long string in it 6"},
-          %{thing: "some long string in it 7"},
-          %{thing: "some long string in it 8"},
-          %{thing: "some long string in it 9"},
-          %{thing: "some long string in it 10"},
-          %{thing: "some long string in it 11"},
-          %{thing: "some long string in it 12"},
-          %{thing: "some long string in it 13"},
-          %{thing: "some long string in it 14"},
-          %{thing: "some long string in it 15"},
-          %{thing: "some long string in it 16"},
-          %{thing: "some long string in it 17"},
-          %{thing: "some long string in it 18"},
-          %{thing: "some long string in it 19"},
-          %{thing: "some long string in it 20"}
-        ],
-        short_list_with_very_long_string: [
-          "Nam elementum iaculis nisi, vitae lacinia erat lacinia id. Proin in dignissim justo. Sed vel luctus " <>
-          "felis. Vestibulum pulvinar tempor commodo. Aenean imperdiet eget nibh vitae scelerisque. Praesent sed " <>
-          "viverra dolor, nec consectetur enim. Curabitur tincidunt posuere ante ac maximus. Vestibulum sit amet " <>
-          "dui sagittis, tempus odio eu, consequat neque. Etiam urna libero, vestibulum nec turpis sit amet, " <>
-          "condimentum venenatis leo. Donec quis ullamcorper mauris. Nunc eget felis velit. Cras molestie est non " <>
-          "justo luctus, et cursus sem gravida. Sed pretium urna id ligula malesuada, venenatis vehicula massa " <>
-          "dapibus. Nullam gravida nisl mauris, eu ultricies nisi condimentum pulvinar. Ut ac vestibulum turpis."
-        ],
-        big_map: %{
-          a: "some long string in it 1",
-          b: "some long string in it 2",
-          c: "some long string in it 3",
-          d: "some long string in it 4",
-          e: "some long string in it 5",
-          f: "some long string in it 6",
-          g: "some long string in it 7",
-          h: "some long string in it 8",
-          i: "some long string in it 9",
-          j: "some long string in it 10",
-          k: "some long string in it 11",
-          l: "some long string in it 12",
-          m: "some long string in it 13",
-          n: "some long string in it 14",
-          o: "some long string in it 15",
-          p: "some long string in it 16",
-          q: "some long string in it 17",
-          r: "some long string in it 18",
-          s: "some long string in it 19",
-          t: "some long string in it 20"
-        },
-        small_map: %{
-          u: "Nam elementum iaculis nisi, vitae lacinia erat lacinia id. Proin in dignissim justo. Sed vel luctus " <>
-          "felis. Vestibulum pulvinar tempor commodo. Aenean imperdiet eget nibh vitae scelerisque. Praesent sed " <>
-          "viverra dolor, nec consectetur enim. Curabitur tincidunt posuere ante ac maximus. Vestibulum sit amet " <>
-          "dui sagittis, tempus odio eu, consequat neque. Etiam urna libero, vestibulum nec turpis sit amet, " <>
-          "condimentum venenatis leo. Donec quis ullamcorper mauris. Nunc eget felis velit. Cras molestie est non " <>
-          "justo luctus, et cursus sem gravida. Sed pretium urna id ligula malesuada, venenatis vehicula massa " <>
-          "dapibus. Nullam gravida nisl mauris, eu ultricies nisi condimentum pulvinar. Ut ac vestibulum turpis."
-        },
-        nested_map: %{
-          v: "some long string in it",
-          w: "Nam elementum iaculis nisi, vitae lacinia erat lacinia id. Proin in dignissim justo.",
-          hash: %{
-            list: [
-              "some long string in it 1",
-              "some long string in it 2"
-            ],
-            something: %{
-              a: "some long string in it 1",
-              b: "some long string in it 2"
+    message =
+      capture_log(fn ->
+        Logger.warn(
+          "Test message",
+          long_list: [
+            "some long string in it 1",
+            "some long string in it 2",
+            "some long string in it 3",
+            "some long string in it 4",
+            "some long string in it 5",
+            "some long string in it 6",
+            "some long string in it 7",
+            "some long string in it 8",
+            "some long string in it 9",
+            "some long string in it 10",
+            "some long string in it 11",
+            "some long string in it 12",
+            "some long string in it 13",
+            "some long string in it 14",
+            "some long string in it 15",
+            "some long string in it 16",
+            "some long string in it 17",
+            "some long string in it 18",
+            "some long string in it 19",
+            "some long string in it 20"
+          ],
+          long_list_with_maps: [
+            %{thing: "some long string in it 1"},
+            %{thing: "some long string in it 2"},
+            %{thing: "some long string in it 3"},
+            %{thing: "some long string in it 4"},
+            %{thing: "some long string in it 5"},
+            %{thing: "some long string in it 6"},
+            %{thing: "some long string in it 7"},
+            %{thing: "some long string in it 8"},
+            %{thing: "some long string in it 9"},
+            %{thing: "some long string in it 10"},
+            %{thing: "some long string in it 11"},
+            %{thing: "some long string in it 12"},
+            %{thing: "some long string in it 13"},
+            %{thing: "some long string in it 14"},
+            %{thing: "some long string in it 15"},
+            %{thing: "some long string in it 16"},
+            %{thing: "some long string in it 17"},
+            %{thing: "some long string in it 18"},
+            %{thing: "some long string in it 19"},
+            %{thing: "some long string in it 20"}
+          ],
+          short_list_with_very_long_string: [
+            "Nam elementum iaculis nisi, vitae lacinia erat lacinia id. Proin in dignissim justo. Sed vel luctus " <>
+              "felis. Vestibulum pulvinar tempor commodo. Aenean imperdiet eget nibh vitae scelerisque. Praesent sed " <>
+              "viverra dolor, nec consectetur enim. Curabitur tincidunt posuere ante ac maximus. Vestibulum sit amet " <>
+              "dui sagittis, tempus odio eu, consequat neque. Etiam urna libero, vestibulum nec turpis sit amet, " <>
+              "condimentum venenatis leo. Donec quis ullamcorper mauris. Nunc eget felis velit. Cras molestie est non " <>
+              "justo luctus, et cursus sem gravida. Sed pretium urna id ligula malesuada, venenatis vehicula massa " <>
+              "dapibus. Nullam gravida nisl mauris, eu ultricies nisi condimentum pulvinar. Ut ac vestibulum turpis."
+          ],
+          big_map: %{
+            a: "some long string in it 1",
+            b: "some long string in it 2",
+            c: "some long string in it 3",
+            d: "some long string in it 4",
+            e: "some long string in it 5",
+            f: "some long string in it 6",
+            g: "some long string in it 7",
+            h: "some long string in it 8",
+            i: "some long string in it 9",
+            j: "some long string in it 10",
+            k: "some long string in it 11",
+            l: "some long string in it 12",
+            m: "some long string in it 13",
+            n: "some long string in it 14",
+            o: "some long string in it 15",
+            p: "some long string in it 16",
+            q: "some long string in it 17",
+            r: "some long string in it 18",
+            s: "some long string in it 19",
+            t: "some long string in it 20"
+          },
+          small_map: %{
+            u:
+              "Nam elementum iaculis nisi, vitae lacinia erat lacinia id. Proin in dignissim justo. Sed vel luctus " <>
+                "felis. Vestibulum pulvinar tempor commodo. Aenean imperdiet eget nibh vitae scelerisque. Praesent sed " <>
+                "viverra dolor, nec consectetur enim. Curabitur tincidunt posuere ante ac maximus. Vestibulum sit amet " <>
+                "dui sagittis, tempus odio eu, consequat neque. Etiam urna libero, vestibulum nec turpis sit amet, " <>
+                "condimentum venenatis leo. Donec quis ullamcorper mauris. Nunc eget felis velit. Cras molestie est non " <>
+                "justo luctus, et cursus sem gravida. Sed pretium urna id ligula malesuada, venenatis vehicula massa " <>
+                "dapibus. Nullam gravida nisl mauris, eu ultricies nisi condimentum pulvinar. Ut ac vestibulum turpis."
+          },
+          nested_map: %{
+            v: "some long string in it",
+            w:
+              "Nam elementum iaculis nisi, vitae lacinia erat lacinia id. Proin in dignissim justo.",
+            hash: %{
+              list: [
+                "some long string in it 1",
+                "some long string in it 2"
+              ],
+              something: %{
+                a: "some long string in it 1",
+                b: "some long string in it 2"
+              }
             }
-          }
-        },
-        number: 1,
-        atom: :atom,
-        long_string:
-          "Nam elementum iaculis nisi, vitae lacinia erat lacinia id. Proin in dignissim justo. Sed vel luctus " <>
-          "felis. Vestibulum pulvinar tempor commodo. Aenean imperdiet eget nibh vitae scelerisque. Praesent sed " <>
-          "viverra dolor, nec consectetur enim. Curabitur tincidunt posuere ante ac maximus. Vestibulum sit amet " <>
-          "dui sagittis, tempus odio eu, consequat neque. Etiam urna libero, vestibulum nec turpis sit amet, " <>
-          "condimentum venenatis leo. Donec quis ullamcorper mauris. Nunc eget felis velit. Cras molestie est non " <>
-          "justo luctus, et cursus sem gravida. Sed pretium urna id ligula malesuada, venenatis vehicula massa " <>
-          "dapibus. Nullam gravida nisl mauris, eu ultricies nisi condimentum pulvinar. Ut ac vestibulum turpis."
-      )
-    end)
+          },
+          number: 1,
+          atom: :atom,
+          long_string:
+            "Nam elementum iaculis nisi, vitae lacinia erat lacinia id. Proin in dignissim justo. Sed vel luctus " <>
+              "felis. Vestibulum pulvinar tempor commodo. Aenean imperdiet eget nibh vitae scelerisque. Praesent sed " <>
+              "viverra dolor, nec consectetur enim. Curabitur tincidunt posuere ante ac maximus. Vestibulum sit amet " <>
+              "dui sagittis, tempus odio eu, consequat neque. Etiam urna libero, vestibulum nec turpis sit amet, " <>
+              "condimentum venenatis leo. Donec quis ullamcorper mauris. Nunc eget felis velit. Cras molestie est non " <>
+              "justo luctus, et cursus sem gravida. Sed pretium urna id ligula malesuada, venenatis vehicula massa " <>
+              "dapibus. Nullam gravida nisl mauris, eu ultricies nisi condimentum pulvinar. Ut ac vestibulum turpis."
+        )
+      end)
 
     decoded_message = Jason.decode!(message)
 
     assert decoded_message["long_list"] == [
-      "some long string in it 1",
-      "some long string in it 2",
-      "some long string in it 3",
-      "some long string in it 4",
-      "some long string in it 5",
-      "some long string in it 6",
-      "-pruned-"
-    ]
+             "some long string in it 1",
+             "some long string in it 2",
+             "some long string in it 3",
+             "some long string in it 4",
+             "some long string in it 5",
+             "some long string in it 6",
+             "-pruned-"
+           ]
+
     assert decoded_message["long_list_with_maps"] == [
-      %{"thing" => "some long string in it 1"},
-      %{"thing" => "some long string in it 2"},
-      %{"thing" => "some long string in it 3"},
-      %{"thing" => "some long string in it 4"},
-      %{"-pruned-" => true}
-    ]
+             %{"thing" => "some long string in it 1"},
+             %{"thing" => "some long string in it 2"},
+             %{"thing" => "some long string in it 3"},
+             %{"thing" => "some long string in it 4"},
+             %{"-pruned-" => true}
+           ]
+
     assert decoded_message["short_list_with_very_long_string"] == [
-      "\"Nam elementum iaculis nisi, vitae lacinia erat lacinia id. Proin in dignissim justo. Sed vel luctus felis. " <>
-      "Vestibulum pulvinar tempor commodo. Aenean imperdiet eget nibh vitae scelerisque. Praesent s (-pruned-)"
-    ]
+             "\"Nam elementum iaculis nisi, vitae lacinia erat lacinia id. Proin in dignissim justo. Sed vel luctus felis. " <>
+               "Vestibulum pulvinar tempor commodo. Aenean imperdiet eget nibh vitae scelerisque. Praesent s (-pruned-)"
+           ]
+
     assert decoded_message["big_map"] == %{
-      "a" => "some long string in it 1",
-      "b" => "some long string in it 2",
-      "c" => "some long string in it 3",
-      "d" => "some long string in it 4",
-      "e" => "some long string in it 5",
-      "-pruned-" => true
-    }
+             "a" => "some long string in it 1",
+             "b" => "some long string in it 2",
+             "c" => "some long string in it 3",
+             "d" => "some long string in it 4",
+             "e" => "some long string in it 5",
+             "-pruned-" => true
+           }
+
     assert decoded_message["small_map"] == %{
-      "u" => "\"Nam elementum iaculis nisi, vitae lacinia erat lacinia id. Proin in dignissim justo. Sed vel luctus " <>
-        "felis. Vestibulum pulvinar tempor commodo. Aenean imperdiet eget nibh vitae scelerisque. Praesent s (-pruned-)"
-    }
+             "u" =>
+               "\"Nam elementum iaculis nisi, vitae lacinia erat lacinia id. Proin in dignissim justo. Sed vel luctus " <>
+                 "felis. Vestibulum pulvinar tempor commodo. Aenean imperdiet eget nibh vitae scelerisque. Praesent s (-pruned-)"
+           }
+
     assert decoded_message["nested_map"] == %{
-      "hash" => %{
-        "list" => [
-          "some long string in it 1",
-          "some long string in it 2"
-        ],
-        "something" => %{
-          "a" => "some long string in it 1",
-          "b" => "some long string in it 2"
-        }
-      },
-      "v" => "some long string in it",
-      "-pruned-" => true
-    }
+             "hash" => %{
+               "list" => [
+                 "some long string in it 1",
+                 "some long string in it 2"
+               ],
+               "something" => %{
+                 "a" => "some long string in it 1",
+                 "b" => "some long string in it 2"
+               }
+             },
+             "v" => "some long string in it",
+             "-pruned-" => true
+           }
+
     assert decoded_message["number"] == 1
     assert decoded_message["atom"] == "atom"
-    assert decoded_message["long_string"] == "\"Nam elementum iaculis nisi, vitae lacinia erat lacinia id. Proin in " <>
-      "dignissim justo. Sed vel luctus felis. Vestibulum pulvinar tempor commodo. Aenean imperdiet eget nibh vitae " <>
-      "scelerisque. Praesent s (-pruned-)"
+
+    assert decoded_message["long_string"] ==
+             "\"Nam elementum iaculis nisi, vitae lacinia erat lacinia id. Proin in " <>
+               "dignissim justo. Sed vel luctus felis. Vestibulum pulvinar tempor commodo. Aenean imperdiet eget nibh vitae " <>
+               "scelerisque. Praesent s (-pruned-)"
   end
 
   defp all_of_same_type?(list) when is_list(list) do


### PR DESCRIPTION
If a log message or its metadata value is a binary which is not encoded
as valid UTF-8, then it cannot be encoded into JSON.

E.g. when the following code is executed:
```
Jason.encode!(<<97, 255>>)
```
then the following error is raised:
```
(Jason.EncodeError) invalid byte 0xFF in <<97, 255>>
```

This commit fixes this problem by removing the
invalid bytes from the string.

One corner case where this solution does not help is when the passed
metadata value is a struct which implements an `Encoder`. In such case
the struct is serialized to JSON with the implemented `Encoder` which
may not prune the invalid bytes.

EN-5883