### PR TITLE
Handle non string map keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.1.3
+
+- Fix crashes when using complex map keys in metadata. 
+  The map key is formatted similarly to all other metadata, but as all resulting keys must be strings:
+    * Should the formatting result be a list, join it with the "," separator.
+    * Should it be anything more complex, replace the key with "unencodable map key".
+  Previously, the formatter raised an error when it encountered such message.
+
 ## 1.1.2
 
 - Allow message and metadata to be logged in cases where it contains invalid UTF-8

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LogstashLoggerFormatter.Mixfile do
   def project do
     [
       app: :logstash_logger_formatter,
-      version: "1.1.2",
+      version: "1.1.3",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/logstash_logger_formatter_test.exs
+++ b/test/logstash_logger_formatter_test.exs
@@ -114,6 +114,25 @@ defmodule LogstashLoggerFormatterTest do
            }
   end
 
+  test "successfully logs MapSets containing tuples" do
+    message =
+      capture_log(fn ->
+        Logger.info("message", foo: MapSet.new(bar: "baz"))
+      end)
+
+    assert message =~ ~r(bar,baz)
+  end
+
+  test "successfully logs maps containing structs as keys" do
+    message =
+      capture_log(fn ->
+        Logger.info("message", foo: %{DateTime.utc_now() => "today"})
+      end)
+
+    assert message =~ "today"
+    assert message =~ "unencodable map key"
+  end
+
   test "truncates metadata" do
     message =
       capture_log(fn ->


### PR DESCRIPTION
When a struct or map is logged which has a complex map key, parsing
failed due to unencodable map keys. Reading complex map keys from logs
is rather difficult, thus take the approach of
1) retaining keys that can be represented as strings
2) join lists with comma separator
3) replace all other keys with unencodable marker

This fixes crashes when logging for example `MapSet.new(foo: "bar")`.