### PR TITLE
Fix crash report ingestion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.1.4
+
+- Allow crash reports to be ingested by ElasticSearch
+  * Omit `crash_reason` and `initial_call` to allow ingestion
+  * Limit crash report message to 100 characters by default to reduce the
+    possibility of logging out sensitive information. A separate error
+    reporting tool should be used to get the full error message and stack
+    trace. The message length limit is configurable via
+    `crash_reports.message_length`.
+
 ## 1.1.3
 
 - Fix crashes when using complex map keys in metadata. 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LogstashLoggerFormatter.Mixfile do
   def project do
     [
       app: :logstash_logger_formatter,
-      version: "1.1.3",
+      version: "1.1.4",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Previously, no crash reports were visible in ElasticSearch / OpenSearch
due to un-parseable metadata fields. Drop the offending fields from
crash reports to allow ingestion.

The crash report message dumps the full state of the process so there is
a significant chance of logging sensitive information. I tried scrubbing
the message of standard secret/PII-containing fields, such as
`req_headers.authorization` and `body_params` from `Plug.Conn`, but I
didn't find a sensible solution, as in crash reports, both the `message`
and `crash_reason` contain objects with arbitrary structure and
complexity.

Finally, I reverted to only including the first 100 characters by
default (configurable in applications), which is nearly always short
enough not to contain secrets. An example message:
```
Process #PID<0.2125.0> terminating
** (exit) {{{%Protocol.UndefinedError{description: "", protocol:
```
Developers should use a separate error reporting tool with secret
scrubbing capability to get the full stack trace.